### PR TITLE
Docker image optimization

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,96 @@
-.git
+# Git repository
+.git/
+.github/
+.gitignore
+
+# Example environment
+.env.example
+
+# Bare metal deployment and configuration
+deploy/
+config/
+
+# Media uploads
+media/
+
+# Private tests
+physionet-django/private-tests.py
+
+# Django database
+db.sqlite3
+
+# Media content created during testing
+physionet-django/static/published-projects/*
+physionet-django/static/wfdbcal
+physionet-django/test.log
+test-upgrade.tmp
+test-upgrade.cache
+
+# Byte-compiled / optimized / DLL files
+**/__pycache__/
+**/*.py[cod]
+**/*$py.class
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+.hypothesis/
+
+# Django stuff:
+**/*.log
+**/local_settings.py
+
+# pyenv
+.python-version
+
+# dotenv
+.env
+
+# virtualenv
+.venv
+venv/
+ENV/
+
+# Spyder project settings
+.spyderproject
+
+# Rope project settings
+.ropeproject
+
+# OSX .DS_Store
+**/.DS_Store
+
+# Patches and related stuff
+**/*.patch
+**/*.orig
+**/*.rej
+
+# Emacs backup and autosave
+**/*~
+**/*#*
+
+# etags
+TAGS
+
+# Credential file
+physionet-django/*credentials*
+
+# VSCode temp file
+.vscode/
+
+# Disk images
+**/*.img
+**/*.iso
+
+# Pycharm / JetBrains / IntelliJ project specific settings folder
+.idea/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,18 @@
-FROM python:3.9
+FROM python:3.9-slim
 
 RUN apt-get update -y \
     && apt-get upgrade -y \
-    && apt-get install postgresql-client -y --no-install-recommends \
+    && apt-get install build-essential postgresql-client zip -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
+RUN pip install poetry \
+    && rm -rf /root/.cache/pip
 
-COPY . /code
-RUN chmod +x /code/wait-for-it.sh
 WORKDIR /code
+COPY pyproject.toml poetry.lock .
 
-RUN pip install poetry
-RUN poetry config virtualenvs.create false
-RUN poetry install --no-root
+RUN poetry config virtualenvs.create false \
+    && poetry install --no-root \
+    && rm -rf /root/.cache/pypoetry /root/.cache/pip
+
+COPY . .
+RUN chmod +x /code/wait-for-it.sh


### PR DESCRIPTION
Uses python-slim instead of python to reduce image size (from about
1.2GB to 600MB).

Installs dependencies before copying code to improve layer caching.

Uses .dockerignore to ignore files that are not needed inside the docker
image.