### PR TITLE
Add "Build, Test and Publish" Github Action

### DIFF
--- a/.github/workflows/docker-build-test.yml
+++ b/.github/workflows/docker-build-test.yml
@@ -1,0 +1,88 @@
+# Builds the PhysioNet docker image and runs tests on the `dev` branch and PRs against the `dev` branch.
+# Publishes the image to DockerHub with `latest` tag when the action runs on the `dev` branch.
+# Can be triggered manually to build, test and optionally publish any branch with a custom tag.
+# All published images are also tagged with corresponding git commit sha.
+#
+# To run the tests locally in a similar environment to GitHub Actions you can use:
+# $ docker-compose -f docker/docker-compose.test.yml build
+# $ docker-compose -f docker/docker-compose.test.yml run --rm test
+# $ docker-compose -f docker/docker-compose.test.yml down
+
+name: Docker / Build, Test and Publish
+
+on:
+  push:
+    branches:
+      - dev
+  pull_request:
+    branches:
+      - dev
+  workflow_dispatch:
+    inputs:
+      publish_tag:
+        description: 'publish_tag: if supplied it will also publish the image as physionet/physionet:<publish_tag>'
+        required: false
+
+jobs:
+  build:
+    name: Build and Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout physionet-build repo
+        uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Build physionet image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          tags: physionet:latest
+          load: true
+
+      - name: Run tests
+        run: docker-compose -f docker/docker-compose.test.yml run --rm test
+
+      - name: Stop and remove containers
+        run: docker-compose -f docker/docker-compose.test.yml down
+
+      - name: Save physionet image
+        if: github.ref == 'refs/heads/dev' || github.event.inputs.publish_tag
+        run: docker save physionet:latest | gzip > /tmp/physionet.tar.gz
+
+      - name: Upload physionet image
+        if: github.ref == 'refs/heads/dev' || github.event.inputs.publish_tag
+        uses: actions/upload-artifact@v2
+        with:
+          name: physionet
+          path: /tmp/physionet.tar.gz
+
+  publish:
+    name: Publish to DockerHub
+    if: github.ref == 'refs/heads/dev' || github.event.inputs.publish_tag
+    environment: dockerhub
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Download physionet image
+        uses: actions/download-artifact@v2
+        with:
+          name: physionet
+          path: /tmp
+
+      - name: Load physionet image
+        run: gunzip -c /tmp/physionet.tar.gz | docker load
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Tag and push
+        run: |
+          docker tag physionet:latest physionet/physionet:${GITHUB_SHA}
+          docker tag physionet:latest physionet/physionet:${{ github.event.inputs.publish_tag || 'latest' }}
+          docker push physionet/physionet:${GITHUB_SHA}
+          docker push physionet/physionet:${{ github.event.inputs.publish_tag || 'latest' }}

--- a/.github/workflows/physionet-build-test.yml
+++ b/.github/workflows/physionet-build-test.yml
@@ -1,5 +1,6 @@
-# a github action on the dev branch that performs a build - test in a docker container
-name: physionet-build-test
+# Installs PhysioNet dependencies on Debian 10 and runs tests on the `dev` branch and PRs against the `dev` branch.
+
+name: Debian / Build and Test
 
 on:
   push:
@@ -10,7 +11,8 @@ on:
       - dev
 
 jobs:
-  container:
+  test:
+    name: Test
     runs-on: ubuntu-latest
     container: debian:10
     env:
@@ -23,16 +25,18 @@ jobs:
       matrix:
         pip3: ['poetry', 'requirements.txt']
     steps:
-      - name: checkout physionet-build repo
+      - name: Checkout physionet-build repo
         uses: actions/checkout@v2
-      - name: update packages
-        run: |
-          apt-get update --yes
-      - name: install and configure needed software
+
+      - name: Update packages
+        run: apt-get update --yes
+
+      - name: Install and configure needed software
         run: |
           apt-get install sudo python3-dev python3-pip build-essential libpq-dev postgresql zip wget python-virtualenv --yes
           ln -sT .env.example .env
-      - name: install repo dependencies
+
+      - name: Install repo dependencies
         # add virtual env path to github_path so each run: process will see it
         run: |
           export VIRTUAL_ENV=/env3
@@ -46,39 +50,36 @@ jobs:
           else
             pip3 install -r requirements.txt
           fi
-      - name: install libseccomp-dev for syscall filtering
-        run: |
-          apt-get install libseccomp-dev
-      - name: setup postgres
+
+      - name: Install libseccomp-dev for syscall filtering
+        run: apt-get install libseccomp-dev
+
+      - name: Setup postgres
         run: |
           service postgresql start
           sudo -u postgres psql -c "create user physionet with superuser password 'password';" -U postgres
           sudo -u postgres psql -c "create database physionet;" -U postgres
-      - name: install and setup wfdb
+
+      - name: Install and setup wfdb
         run: |
           wget https://github.com/bemoody/wfdb/archive/10.6.2.tar.gz -O wfdb.tar.gz
           tar -xf wfdb.tar.gz
           (cd wfdb-* && ./configure --without-netfiles && make -C lib install && make -C data install)
-      - name: run linker for newly installed software
-        run: |
-          ldconfig
-      - name: install and setup lightwave
+
+      - name: Run linker for newly installed software
+        run: ldconfig
+
+      - name: Install and setup lightwave
         run: |
           wget https://github.com/bemoody/lightwave/archive/bfe908a7f53434df61fd2444bf8c235e3e6226fc.tar.gz -O lightwave.tar.gz
           tar -xf lightwave.tar.gz
           (cd lightwave-* && make CGIDIR=/usr/local/bin sandboxed-server)
-      - name: install web driver - geckodriver
-        run: |
-          wget https://github.com/mozilla/geckodriver/releases/download/v0.23.0/geckodriver-v0.23.0-linux64.tar.gz
-          mkdir geckodriver
-          tar -xf geckodriver-v0.23.0-linux64.tar.gz -C geckodriver
-          echo "$PWD/geckodriver" >> $GITHUB_PATH
-      - name: setup and test physionet, check amount of code tested
+
+      - name: Setup and test physionet, check amount of code tested
         run: |
           cd physionet-django
           python manage.py makemigrations --dry-run --no-input --check
           python manage.py resetdb
           python manage.py loaddemo
-          python manage.py test --verbosity=3 --keepdb
-          coverage run --source='.' manage.py test --keepdb
+          coverage run --source='.' manage.py test --verbosity=3 --keepdb
           coverage report -m

--- a/docker/docker-compose.test.yml
+++ b/docker/docker-compose.test.yml
@@ -1,0 +1,22 @@
+version: '3.9'
+
+services:
+  test:
+    image: physionet:latest
+    build: ..
+    depends_on:
+      - db
+    environment:
+      DJANGO_SETTINGS_MODULE: physionet.settings.settings
+      DB_HOST: db
+      DB_NAME: physionet_test
+      MEDIA_ROOT: /data/pn-media
+      STATIC_ROOT: /data/pn-static
+    env_file: ../.env.example
+    entrypoint: ./docker/test-entrypoint.sh
+  db:
+    image: postgres:13-alpine
+    environment:
+      POSTGRES_USER: physionet
+      POSTGRES_PASSWORD: password
+      POSTGRES_DB: physionet_test

--- a/docker/test-entrypoint.sh
+++ b/docker/test-entrypoint.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -e
+
+mkdir -p $STATIC_ROOT/published-projects
+mkdir -p $MEDIA_ROOT/{active-projects,archived-projects,credential-applications,published-projects,users}
+
+./docker/wait-for-it.sh $DB_HOST:5432
+
+cd physionet-django
+python manage.py makemigrations --dry-run --no-input --check
+python manage.py resetdb
+python manage.py loaddemo
+coverage run --source='.' manage.py test --verbosity=3 --keepdb
+coverage report -m


### PR DESCRIPTION
## Adds a GitHub Action that:
- Builds the PhysioNet docker image and runs tests on the `dev` branch and PRs against the `dev` branch.
- Publishes the image to DockerHub with `latest` tag when the action runs on the `dev` branch.
- Can be triggered manually to build, test and optionally publish any branch with a custom tag.
- Tags all published images with corresponding git commit sha.

## Running CI test locally

To run the tests locally in a similar environment to GitHub Actions you can use:

```sh
docker-compose -f docker/docker-compose.test.yml build
docker-compose -f docker/docker-compose.test.yml run --rm test
docker-compose -f docker/docker-compose.test.yml down
```

## Deploying manually

To run the action manually go to `Actions` -> `Docker / Build, Test and Publish` and select `Run workflow`. If `published_tag` is specified the action will publish the image with the given tag. Otherwise it will only build the image and run tests.

<img width="1242" alt="Screenshot 2021-07-12 at 11 56 50" src="https://user-images.githubusercontent.com/31316592/125272019-a5c18280-e30b-11eb-9ea6-daee0c44e704.png">

## Github environment requirements

To successfully publish the image an environment called `dockerhub` with
secrets `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` should be configured.
The environment should also have protection rules specified (for example
setting `dev` as the deployment branch and adding reviewers for
publishing other branches).

If a review is required it needs to approved before the image is published:

<img width="1402" alt="Screenshot 2021-07-12 at 12 22 13" src="https://user-images.githubusercontent.com/31316592/125272332-02bd3880-e30c-11eb-905e-9b6bd8235f4c.png">

<img width="655" alt="Screenshot 2021-07-12 at 12 22 25" src="https://user-images.githubusercontent.com/31316592/125272349-081a8300-e30c-11eb-9565-8256f9791776.png">