### PR TITLE
Leave ethics section empty for published projects.

### DIFF
--- a/physionet-django/project/forms.py
+++ b/physionet-django/project/forms.py
@@ -1124,7 +1124,7 @@ class UploadedDocumentFormSet(BaseGenericInlineFormSet):
         super().__init__(*args, **kwargs)
         url = f'{reverse_lazy("about_publish")}#guidelines'
         self.help_text = (
-            "Please provide an ethics statement following the"
+            "Please provide an ethics statement following the "
             f"<a href='{url}' target='_blank'>author guidelines</a>. "
             "Statements on ethics approval should appear here. "
             "Your statement will be included in the public project description."

--- a/physionet-django/project/migrations/0050_ethics_statement_2.py
+++ b/physionet-django/project/migrations/0050_ethics_statement_2.py
@@ -13,7 +13,7 @@ def migrate_forward(apps, schema_editor):
 
     ActiveProject.objects.update(ethics_statement="The authors declare no ethics concerns.")
     ArchivedProject.objects.update(ethics_statement="The authors declare no ethics concerns.")
-    PublishedProject.objects.update(ethics_statement="The authors declare no ethics concerns.")
+    PublishedProject.objects.update(ethics_statement="")
 
 
 def migrate_backward(apps, schema_editor):


### PR DESCRIPTION
It could be misleading to populate previously published projects with this statement. Instead, please leave this blank. The project templates will omit the ethics section when empty.

Not sure whether me making this PR to your branch makes things easier or not, but thought I'd give it a try (blame @alistairewj for the idea!).