### PR TITLE
Remove account migration notification

### DIFF
--- a/physionet-django/user/templates/user/login.html
+++ b/physionet-django/user/templates/user/login.html
@@ -30,11 +30,5 @@
   <div class="form-signin">
     <p>New user? <a id="register" href="{% url 'register' %}">Create an account</a></p>
   </div>
-  <div class="alert alert-warning alert-dismissible fade show" role="alert">
-    <button type="button" class="close" data-dismiss="alert" aria-label="Close">
-      <span aria-hidden="true">&times;</span>
-    </button>
-    Previous {{ SITE_NAME }} user? Please create an account on the new website. If you register using the same email address as before, your permission to access protected databases such as MIMIC-III will be automatically transferred.
-  </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
This PR removes the account migration  notification which was displayed on the login page.