### PR TITLE
Introduce random suffix to CloudIdentity gcp_user_id

### DIFF
--- a/physionet-django/environment/services.py
+++ b/physionet-django/environment/services.py
@@ -20,7 +20,11 @@ from environment.entities import (
     InstanceType,
     Region,
 )
-from environment.utilities import left_join_iterators, inner_join_iterators
+from environment.utilities import (
+    left_join_iterators,
+    inner_join_iterators,
+    gcp_user_id_for_user,
+)
 from user.models import User
 from project.models import AccessPolicy, PublishedProject
 
@@ -34,7 +38,7 @@ def _environment_data_group(environment: ResearchEnvironment) -> str:
 
 
 def create_cloud_identity(user: User) -> Tuple[str, CloudIdentity]:
-    gcp_user_id = f"researcher-{user.username}"
+    gcp_user_id = gcp_user_id_for_user(user)
     response = api.create_cloud_identity(
         gcp_user_id, user.profile.first_names, user.profile.last_name
     )

--- a/physionet-django/environment/utilities.py
+++ b/physionet-django/environment/utilities.py
@@ -1,4 +1,6 @@
+import random
 from typing import Iterator, Tuple, Optional, TypeVar, Callable
+from string import ascii_uppercase
 
 from user.models import User
 
@@ -6,6 +8,19 @@ from user.models import User
 T = TypeVar("T")
 U = TypeVar("U")
 V = TypeVar("V")
+
+
+def gcp_user_id_for_user(user: User, random_suffix_length: int = 3) -> str:
+    max_username_length = User._meta.get_field("username").max_length
+    max_truncated_username_length = max_username_length - random_suffix_length - 1
+    username = user.username
+    truncated_username = (
+        username[:max_truncated_username_length]
+        if len(username) > max_truncated_username_length
+        else username
+    )
+    random_suffix = "".join(random.choices(ascii_uppercase, k=random_suffix_length))
+    return f"{truncated_username}-{random_suffix}"
 
 
 def user_has_cloud_identity(user: User) -> bool:


### PR DESCRIPTION
This PR also makes one requirement pretty clear - we should probably add a new page into the User profile that will list:
* GCP User Id
* GCP Email
* Billing Account ID