### PR TITLE
Integrate with user-info API endpoint to retrieve the user's lost OTP

### DIFF
--- a/physionet-django/environment/api/__init__.py
+++ b/physionet-django/environment/api/__init__.py
@@ -14,6 +14,11 @@ def create_cloud_identity(
 
 
 @api_request
+def get_user_info(gcp_user_id: str) -> Request:
+    return Request("GET", url=f"/user/{gcp_user_id}")
+
+
+@api_request
 def create_workspace(gcp_user_id: str, billing_id: str, region: str) -> Request:
     json = {"userid": gcp_user_id, "billingid": billing_id, "region": region}
     return Request("POST", url="/onetimeplatformsetup", json=json)

--- a/physionet-django/environment/exceptions.py
+++ b/physionet-django/environment/exceptions.py
@@ -30,5 +30,9 @@ class GetAvailableEnvironmentsFailed(Exception):
     pass
 
 
+class GetUserInfoFailed(Exception):
+    pass
+
+
 class GetWorkspaceDetailsFailed(Exception):
     pass

--- a/physionet-django/environment/services.py
+++ b/physionet-django/environment/services.py
@@ -47,10 +47,10 @@ def _environment_data_group(environment: ResearchEnvironment) -> str:
     return environment.group_granting_data_access
 
 
-def create_cloud_identity_object(user: User, gcp_user_id: str, email: str) -> CloudIdentity:
-    return CloudIdentity.objects.create(
-        user=user, gcp_user_id=gcp_user_id, email=email
-    )
+def create_cloud_identity_object(
+    user: User, gcp_user_id: str, email: str
+) -> CloudIdentity:
+    return CloudIdentity.objects.create(user=user, gcp_user_id=gcp_user_id, email=email)
 
 
 def create_cloud_identity(user: User) -> Tuple[str, CloudIdentity]:
@@ -63,7 +63,9 @@ def create_cloud_identity(user: User) -> Tuple[str, CloudIdentity]:
         raise IdentityProvisioningFailed(error_message)
 
     body = response.json()
-    identity = create_cloud_identity_object(user=user, gcp_user_id=gcp_user_id, email=body["email-id"])
+    identity = create_cloud_identity_object(
+        user=user, gcp_user_id=gcp_user_id, email=body["email-id"]
+    )
     otp = body["one-time-password"]
     return otp, identity
 
@@ -71,7 +73,9 @@ def create_cloud_identity(user: User) -> Tuple[str, CloudIdentity]:
 def get_user_info(user: User):
     response = api.get_user_info(gcp_user_id=user.username)
 
-    if not response.ok:  # right now response form API is always ok (maybe except Runtime)
+    if (
+        not response.ok
+    ):  # right now response form API is always ok (maybe except Runtime)
         error_message = response.json()["message"]
         raise GetUserInfoFailed(error_message)
 

--- a/physionet-django/environment/services.py
+++ b/physionet-django/environment/services.py
@@ -47,12 +47,6 @@ def _environment_data_group(environment: ResearchEnvironment) -> str:
     return environment.group_granting_data_access
 
 
-def create_cloud_identity_object(
-    user: User, gcp_user_id: str, email: str
-) -> CloudIdentity:
-    return CloudIdentity.objects.create(user=user, gcp_user_id=gcp_user_id, email=email)
-
-
 def create_cloud_identity(user: User) -> Tuple[str, CloudIdentity]:
     gcp_user_id = user.username
     response = api.create_cloud_identity(
@@ -63,9 +57,7 @@ def create_cloud_identity(user: User) -> Tuple[str, CloudIdentity]:
         raise IdentityProvisioningFailed(error_message)
 
     body = response.json()
-    identity = create_cloud_identity_object(
-        user=user, gcp_user_id=gcp_user_id, email=body["email-id"]
-    )
+    identity = CloudIdentity.objects.create(user=user, gcp_user_id=gcp_user_id, email=body["email-id"])
     otp = body["one-time-password"]
     return otp, identity
 

--- a/physionet-django/environment/views.py
+++ b/physionet-django/environment/views.py
@@ -20,23 +20,21 @@ from environment.utilities import (
     user_has_cloud_identity,
     user_has_billing_setup,
 )
-from environment.models import Workflow
+from environment.models import Workflow, CloudIdentity
 
 
 @require_http_methods(["GET", "POST"])
 @login_required
 def identity_provisioning(request):
-    # assuming that if user has could_identity => user has cloud_identity in API
     if user_has_cloud_identity(request.user):
         return redirect("billing_setup")
 
-    # user has no cloud identity, and now we check if he has cloud identity in API
     user_info = services.get_user_info(request.user)
     if user_info.get("user-status") == "user-added-in-cloud-identity":
-        _identity = services.create_cloud_identity_object(
+        CloudIdentity.objects.create(
             user=request.user,
             gcp_user_id=user_info.get("user-id"),
-            email=user_info.get("email"),
+            email=user_info.get("email-id"),
         )
         return redirect("billing_setup")
 

--- a/physionet-django/environment/views.py
+++ b/physionet-django/environment/views.py
@@ -32,11 +32,11 @@ def identity_provisioning(request):
 
     # user has no cloud identity, and now we check if he has cloud identity in API
     user_info = services.get_user_info(request.user)
-    if user_info.get('user-status') == 'user-added-in-cloud-identity':
+    if user_info.get("user-status") == "user-added-in-cloud-identity":
         _identity = services.create_cloud_identity_object(
             user=request.user,
-            gcp_user_id=user_info.get('user-id'),
-            email=user_info.get('email'),
+            gcp_user_id=user_info.get("user-id"),
+            email=user_info.get("email"),
         )
         return redirect("billing_setup")
 


### PR DESCRIPTION
Integration with the new user-info endpoint that returns the user’s OTP to use in case the API response is lost. Now we have mechanism to differentiate between a user that has no cloud identity in the API and a user that has a cloud identity in the API but it wasn’t persisted in our DB.